### PR TITLE
Put the reference inside the <a> tag

### DIFF
--- a/org-ref-ox-hugo.el
+++ b/org-ref-ox-hugo.el
@@ -32,7 +32,7 @@
   ;; We create an anchor to the key that we can jump to, and provide a jump back
   ;; link with the md5 of the key.
   (let ((org-ref-formatted-citation-backend "md"))
-    (format "<a id=\"%s\"></a>%s [↩](#%s)"
+    (format "<a id=\"%s\">%s</a> [↩](#%s)"
             key
             (org-ref-format-entry key)
             (md5 key))))


### PR DESCRIPTION
I think that the bibliography references should be put inside the <a> tag as it seems to be the case on your website (https://braindump.jethro.dev/).
This way, we can see the linked reference with the `:hover` css property.